### PR TITLE
Sprint 8 add comments to tickets

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,2 @@
+class CommentsController < ApplicationController
+end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -6,6 +6,19 @@ class CommentsController < ApplicationController
 
   def show; end
 
+  def create
+    @comment = Comment.new(worker_id: params[:comment][:worker_id],
+                           ticket_id: params[:ticket_id],
+                           message: params[:comment][:message],
+                           reply_to_comment_id: params[:comment][:reply_to_comment_id])
+
+    if @comment.save
+      render :show, status: :created, location: @ticket_comment
+    else
+      render json: @comment.errors, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def set_comment

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -13,6 +13,7 @@ class CommentsController < ApplicationController
                            reply_to_comment_id: params[:comment][:reply_to_comment_id])
 
     if @comment.save
+      @comment.ticket.update(comments_count: @comment.ticket.comments_count + 1)
       render :show, status: :created, location: @ticket_comment
     else
       render json: @comment.errors, status: :unprocessable_entity
@@ -28,6 +29,15 @@ class CommentsController < ApplicationController
       end
     else
       forbidden_message('Only author can edit this comment!')
+    end
+  end
+
+  def destroy
+    if @comment.destroy
+      @comment.ticket.update(comments_count: @comment.ticket.comments_count - 1)
+      render json: { message: 'Comment was deleted' }, status: :ok
+    else
+      render json: @comment.errors, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,7 +1,7 @@
 class CommentsController < ApplicationController
   before_action :set_comment, only: %i[show update destroy]
   def index
-    @comments = Comment.where(ticket_id: params[:ticket_id].to_i)
+    @comments = Comment.where(ticket_id: params[:ticket_id].to_i).order(:created_at)
   end
 
   def show; end
@@ -16,6 +16,18 @@ class CommentsController < ApplicationController
       render :show, status: :created, location: @ticket_comment
     else
       render json: @comment.errors, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @comment.worker_id == current_user.id
+      if @comment.update(message: params[:comment][:message])
+        render :show, status: :ok, location: @ticket_comment
+      else
+        render json: @comment.errors, status: :unprocessable_entity
+      end
+    else
+      forbidden_message('Only author can edit this comment!')
     end
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -34,7 +34,7 @@ class CommentsController < ApplicationController
         forbidden_message('Only author can edit this comment!')
       end
     else
-      render json: { error: 'Messages can only be edited for the first 6 hours!' }
+      render json: { error: 'Messages can only be edited for the first 6 hours!' }, status: :forbidden
     end
   end
 
@@ -51,7 +51,7 @@ class CommentsController < ApplicationController
         forbidden_message('Only author can delete this comment!')
       end
     else
-      render json: { error: 'Messages can only be deleted for the first hour!' }
+      render json: { error: 'Messages can only be deleted for the first hour!' }, status: :forbidden
     end
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,5 +1,16 @@
 class CommentsController < ApplicationController
+  before_action :set_comment, only: %i[show update destroy]
   def index
     @comments = Comment.where(ticket_id: params[:ticket_id].to_i)
+  end
+
+  def show; end
+
+  private
+
+  def set_comment
+    @comment = Comment.where(ticket_id: params[:ticket_id].to_i).find(params[:id])
+  rescue ActiveRecord::RecordNotFound => e
+    render json: { error: e.message }, status: :not_found
   end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -14,6 +14,7 @@ class CommentsController < ApplicationController
                            reply_to_comment_id: params[:comment][:reply_to_comment_id])
 
     if @comment.save
+      email_for_mentions
       @comment.ticket.update(comments_count: @comment.ticket.comments_count + 1)
       render :show, status: :created, location: @ticket_comment
     else
@@ -60,5 +61,9 @@ class CommentsController < ApplicationController
     @comment = Comment.where(ticket_id: params[:ticket_id].to_i).find(params[:id])
   rescue ActiveRecord::RecordNotFound => e
     render json: { error: e.message }, status: :not_found
+  end
+
+  def email_for_mentions
+    name = @comment.message.match(/@[a-zA-Z]+_[a-zA-Z]+/)
   end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,2 +1,5 @@
 class CommentsController < ApplicationController
+  def index
+    @comments = Comment.where(ticket_id: params[:ticket_id].to_i)
+  end
 end

--- a/app/mailers/comments_mailer.rb
+++ b/app/mailers/comments_mailer.rb
@@ -1,0 +1,7 @@
+class CommentsMailer < ApplicationMailer
+  def new_mention
+    @mentioned_worker = params[:mentioned]
+    @comment = params[:comment]
+    mail(to: @mentioned_worker.user.email, subject: 'New mention!')
+  end
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,5 +1,6 @@
 class Comment < ApplicationRecord
   belongs_to :ticket
+  belongs_to :worker
 
   belongs_to :reply_to, class_name: 'Comment', foreign_key: 'reply_to_comment_id', optional: true
   has_many :replies, class_name: 'Comment', foreign_key: 'reply_to_comment_id'

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,6 @@
+class Comment < ApplicationRecord
+  belongs_to :ticket
+
+  belongs_to :reply_to, class_name: 'Comment', foreign_key: 'reply_to_comment_id', optional: true
+  has_many :replies, class_name: 'Comment', foreign_key: 'reply_to_comment_id'
+end

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -7,6 +7,8 @@ class Ticket < ApplicationRecord
   belongs_to :worker
   belongs_to :creator_worker, class_name: 'Worker'
 
+  has_many :comments
+
   validates :title, length: { maximum: 40 }
   validates :worker_id, presence: true
   validates :state, inclusion: { in: ['Pending', 'In progress', 'Done'],

--- a/app/views/comments/_comment.json.jbuilder
+++ b/app/views/comments/_comment.json.jbuilder
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-json.set! :worker, "#{comment.ticket.worker.first_name} #{comment.ticket.worker.last_name}"
+json.set! :worker, "#{comment.worker.first_name} #{comment.worker.last_name}"
 json.set! :ticket, comment.ticket.title
 json.set! :message, comment.message
 json.set! :reply_to, comment.reply_to

--- a/app/views/comments/_comment.json.jbuilder
+++ b/app/views/comments/_comment.json.jbuilder
@@ -3,4 +3,4 @@
 json.set! :worker, "#{comment.worker.first_name} #{comment.worker.last_name}"
 json.set! :ticket, comment.ticket.title
 json.set! :message, comment.message
-json.set! :reply_to, comment.reply_to
+json.set! :reply_to_comment_id, comment.reply_to_comment_id

--- a/app/views/comments/_comment.json.jbuilder
+++ b/app/views/comments/_comment.json.jbuilder
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+json.set! :worker, "#{comment.ticket.worker.first_name} #{comment.ticket.worker.last_name}"
+json.set! :ticket, comment.ticket.title
+json.set! :message, comment.message
+json.set! :reply_to, comment.reply_to

--- a/app/views/comments/index.json.jbuilder
+++ b/app/views/comments/index.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.array! @comments, partial: 'comments/comment', as: :comment

--- a/app/views/comments/show.json.jbuilder
+++ b/app/views/comments/show.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! 'comments/comment', comment: @comment

--- a/app/views/comments_mailer/new_mention.html.erb
+++ b/app/views/comments_mailer/new_mention.html.erb
@@ -1,0 +1,3 @@
+<p>You have been mentioned in comment!</p>
+<p>Comment: "<%=@comment.message%>"</p>
+<p>Mentioned by: <%= "#{@comment.worker.first_name} #{@comment.worker.last_name}"%></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,9 @@ Rails.application.routes.draw do
                registrations: 'users/registrations'
              }
   resources :workers
-  resources :tickets
+  resources :tickets do
+    resources :comments
+  end
   put 'workers/:id/activate', to: 'workers#activate'
   put 'workers/:id/deactivate', to: 'workers#deactivate'
   put 'tickets/:id/change-state', to: 'tickets#change_state'

--- a/db/migrate/20220818153007_add_comments_count_to_ticket.rb
+++ b/db/migrate/20220818153007_add_comments_count_to_ticket.rb
@@ -1,0 +1,5 @@
+class AddCommentsCountToTicket < ActiveRecord::Migration[6.1]
+  def change
+    add_column :tickets, :comments_count, :integer
+  end
+end

--- a/db/migrate/20220818154113_add_default_value_to_comments_count.rb
+++ b/db/migrate/20220818154113_add_default_value_to_comments_count.rb
@@ -1,0 +1,9 @@
+class AddDefaultValueToCommentsCount < ActiveRecord::Migration[6.1]
+  def up
+    change_column_default :tickets, :comments_count, 0
+  end
+
+  def down
+    change_column_default :tickets, :comments_count, nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_18_153007) do
+ActiveRecord::Schema.define(version: 2022_08_18_154113) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,7 +38,7 @@ ActiveRecord::Schema.define(version: 2022_08_18_153007) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "creator_worker_id"
-    t.integer "comments_count"
+    t.integer "comments_count", default: 0
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_18_091622) do
+ActiveRecord::Schema.define(version: 2022_08_18_153007) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,6 +38,7 @@ ActiveRecord::Schema.define(version: 2022_08_18_091622) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "creator_worker_id"
+    t.integer "comments_count"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -17,4 +17,8 @@ if Rails.env.test?
   User.create({ email: 'ted@gmail.com', password: 'test pass', worker: workers[2], is_admin: false })
   User.create({ email: 'john@gmail.com', password: 'test pass', worker: workers[3], is_admin: false })
   User.create({ email: 'ben@gmail.com', password: 'test pass', worker: workers[4], is_admin: false })
+
+  Comment.create({ worker_id: 1, ticket_id: 1, message: 'Hiiii!', reply_to_comment_id: nil })
+  Comment.create({ worker_id: 2, ticket_id: 1, message: 'Hi!', reply_to_comment_id: 1 })
+  Comment.create({ worker_id: 3, ticket_id: 1, message: 'Hello!', reply_to_comment_id: 2 })
 end

--- a/spec/mailers/comments_spec.rb
+++ b/spec/mailers/comments_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe CommentsMailer, type: :mailer do
+  describe '#new_mention' do
+    let(:mail) do
+      CommentsMailer.with(mentioned: Worker.last,
+                          comment: Comment.first).new_mention
+    end
+    it 'renders the headers' do
+      expect(mail.subject).to eq('New mention!')
+      expect(mail.to).to eq(['ben@gmail.com'])
+      expect(mail.from).to eq(['test@example.com'])
+    end
+    it 'renders the body' do
+      expect(mail.body.encoded).to match('You have been mentioned in comment!')
+      expect(mail.body.encoded).to match('Comment: "Hiiii!"')
+      expect(mail.body.encoded).to match('Mentioned by: Nazar Tester')
+    end
+  end
+end

--- a/spec/mailers/previews/comments_preview.rb
+++ b/spec/mailers/previews/comments_preview.rb
@@ -1,0 +1,9 @@
+# Preview all emails at http://localhost:3000/rails/mailers/comments
+class CommentsPreview < ActionMailer::Preview
+  def new_mention
+    @user = Worker.last
+    @comment = Comment.first
+    CommentsMailer.with(mentioned: @user,
+                        comment: @comment).new_mention
+  end
+end

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Comments", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -3,6 +3,108 @@ require 'devise/jwt/test_helpers'
 
 RSpec.describe 'Comments', type: :request do
   context 'with valid authentication' do
+    before { sign_in User.first }
+
+    context 'GET /tickets/1/comments' do
+      before { get '/tickets/1/comments', as: :json }
+
+      it { expect(response).to have_http_status(:ok) }
+      it { expect(response).to render_template(:index) }
+    end
+
+    context 'GET /tickets/1/comments/1' do
+      before { get '/tickets/1/comments/1', as: :json }
+
+      it { expect(response).to have_http_status(:ok) }
+      it { expect(response).to render_template(:show) }
+    end
+
+    context 'POST /tickets/1/comments' do
+      before do
+        post '/tickets/1/comments',
+             params: {
+               comment: { worker_id: 2,
+                          message: 'test comment',
+                          reply_to_comment_id: nil },
+               format: :json
+             }
+      end
+
+      it { expect(response).to have_http_status(:created) }
+      it { expect(response).to render_template(:show) }
+      it { expect(Comment.where(message: 'test comment').first.id).to eq(Comment.last.id) }
+    end
+
+    context 'PUT /tickets/1/comments' do
+      context 'when edited by author' do
+        context 'when message is less than 6 hours old' do
+          before do
+            put '/tickets/1/comments/1',
+                params: {
+                  comment: { message: 'test comment' },
+                  format: :json
+                }
+          end
+
+          it { expect(response).to have_http_status(:ok) }
+          it { expect(response).to render_template(:show) }
+        end
+
+        context 'when message is more than 6 hours old' do
+          before do
+            Comment.first.update(created_at: '2022-08-17 00:00:00')
+            put '/tickets/1/comments/1',
+                params: {
+                  comment: { message: 'test comment' },
+                  format: :json
+                }
+          end
+
+          it { expect(response).to have_http_status(:forbidden) }
+          it { expect(response.parsed_body['error']).to eq('Messages can only be edited for the first 6 hours!') }
+        end
+      end
+
+      context 'when edited by other user' do
+        before do
+          put '/tickets/1/comments/2',
+              params: {
+                comment: { message: 'test comment' },
+                format: :json
+              }
+        end
+
+        it { expect(response).to have_http_status(:forbidden) }
+        it { expect(response.parsed_body['error']).to eq('Only author can edit this comment!') }
+      end
+    end
+
+    context 'DELETE /tickets/1/comments' do
+      context 'when deleted by author' do
+        context 'when message is less than hour old' do
+          before { delete '/tickets/1/comments/1', as: :json }
+
+          it { expect(response).to have_http_status(:ok) }
+          it { expect(response.parsed_body['message']).to eq('Comment was deleted') }
+        end
+        context 'when message is more than hour old' do
+          before do
+            Comment.first.update(created_at: '2022-08-17 00:00:00')
+            delete '/tickets/1/comments/1', as: :json
+          end
+
+          it { expect(response).to have_http_status(:forbidden) }
+          it { expect(response.parsed_body['error']).to eq('Messages can only be deleted for the first hour!') }
+        end
+      end
+
+      context 'when deleted by other user' do
+        before { delete '/tickets/1/comments/2', as: :json }
+
+        it { expect(response).to have_http_status(:forbidden) }
+        it { expect(response.parsed_body['error']).to eq('Only author can delete this comment!') }
+      end
+    end
   end
   context 'without authentication' do
     context 'GET /tickets/1/comments' do

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -1,7 +1,43 @@
 require 'rails_helper'
+require 'devise/jwt/test_helpers'
 
-RSpec.describe "Comments", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+RSpec.describe 'Comments', type: :request do
+  context 'with valid authentication' do
+  end
+  context 'without authentication' do
+    context 'GET /tickets/1/comments' do
+      before { get '/tickets/1/comments', as: :json }
+
+      it { expect(response).to have_http_status(:ok) }
+      it { expect(response).to render_template(:index) }
+    end
+
+    context 'GET /tickets/1/comments/1' do
+      before { get '/tickets/1/comments/1', as: :json }
+
+      it { expect(response).to have_http_status(:ok) }
+      it { expect(response).to render_template(:show) }
+    end
+
+    context 'POST /tickets/1/comments' do
+      before { post '/tickets/1/comments', as: :json }
+
+      it { expect(response).to have_http_status(:unauthorized) }
+      it { expect(response.parsed_body['error']).to eq('You need to log in to continue!') }
+    end
+
+    context 'PUT /tickets/1/comments' do
+      before { put '/tickets/1/comments/1', as: :json }
+
+      it { expect(response).to have_http_status(:unauthorized) }
+      it { expect(response.parsed_body['error']).to eq('You need to log in to continue!') }
+    end
+
+    context 'DELETE /tickets/1/comments' do
+      before { delete '/tickets/1/comments/1', as: :json }
+
+      it { expect(response).to have_http_status(:unauthorized) }
+      it { expect(response.parsed_body['error']).to eq('You need to log in to continue!') }
+    end
   end
 end


### PR DESCRIPTION
Added comments [table](https://github.com/sadattachi/TaskManagementApp/blob/sprint-8-add-comments-to-tickets/db/schema.rb) and [model](https://github.com/sadattachi/TaskManagementApp/blob/sprint-8-add-comments-to-tickets/app/models/comment.rb).
Added comments [controller](https://github.com/sadattachi/TaskManagementApp/blob/sprint-8-add-comments-to-tickets/app/controllers/comments_controller.rb) with CRUD actions.
Added comments [mailer](https://github.com/sadattachi/TaskManagementApp/blob/sprint-8-add-comments-to-tickets/app/mailers/comments_mailer.rb) to notify user about mentions in comments.